### PR TITLE
Fix reseller path

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A couple things before you start.  First, identify the type of role that best su
         + `/var/cpanel/customizations/styled/cP_Starter_Dark/`
         
     - **Reseller**: 
-        + `var/cpanel/reseller/styled/cP_Starter_Dark/`
+        + `/home/reseller/var/cpanel/reseller/styled/cP_Starter_Dark/`
         
     - **cPanel User**: 
         + `/home/username/var/cpanel/styled/cP_Starter_Dark/` *(Note: username - represents the cPanel account's username)*


### PR DESCRIPTION
Prefixing the reseller path in the extracted files section so that it communicates that the full path should exist inside the reseller's home
